### PR TITLE
Upgrade clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ matrix:
     # debug+santizer build
     - os: linux
       compiler: clang
-      env: CLANG_VERSION='3.8.0' BUILDTYPE=Debug CC="clang" CXX="clang++" CXXFLAGS="-fsanitize=address,undefined,integer -fno-sanitize-recover=all" CFLAGS="-fsanitize=address,undefined,integer -fno-sanitize-recover=all" LDFLAGS="-fsanitize=address,undefined,integer"
+      sudo: true # to workaround https://github.com/mapbox/node-cpp-skel/issues/93
+      env: CLANG_VERSION='5.0.1' BUILDTYPE=Debug CC="clang" CXX="clang++" CXXFLAGS="-fsanitize=address,undefined,integer -fsanitize-address-use-after-scope -fno-sanitize-recover=all" CFLAGS="-fsanitize=address,undefined,integer -fsanitize-address-use-after-scope -fno-sanitize-recover=all" LDFLAGS="-fsanitize=address,undefined,integer"
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test' ]
@@ -30,7 +31,7 @@ matrix:
     # coverage+debug build
     - os: linux
       compiler: clang
-      env: CLANG_VERSION='5.0.0' BUILDTYPE=Debug CC="clang" CXX="clang++" CXXFLAGS="--coverage" CFLAGS="--coverage" LDFLAGS="--coverage"
+      env: CLANG_VERSION='5.0.1' BUILDTYPE=Debug CC="clang" CXX="clang++" CXXFLAGS="--coverage" CFLAGS="--coverage" LDFLAGS="--coverage"
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test' ]
@@ -46,7 +47,7 @@ matrix:
     # release+linux+clang++
     - os: linux
       compiler: clang
-      env: CLANG_VERSION='5.0.0' BUILDTYPE=Release CC="clang" CXX="clang++"
+      env: CLANG_VERSION='5.0.1' BUILDTYPE=Release CC="clang" CXX="clang++"
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test' ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from ubuntu
-FROM ubuntu:17.04
+FROM ubuntu:16.04
 
 # Update repos and install dependencies
 RUN apt-get update \


### PR DESCRIPTION
This reverts https://github.com/mapbox/tile-count/pull/51/commits/3fd006d3d8ef4abe98d05e0bfbf49a8fac9d9449 which is an undesirable workaround since it disables Leak checking. A much better way to keep leak checking is to keep the latest clang but run with `sudo: true` per the code comment.

refs https://github.com/mapbox/node-cpp-skel/issues/93